### PR TITLE
Use regular expressions to filter versions

### DIFF
--- a/sami_config.php
+++ b/sami_config.php
@@ -18,7 +18,7 @@ $composer = (new \Concrete5\Api\Composer\Composer($filesystem, $inputDir))
 // Set up a new version collection that gets versions from packagist
 $versions = \Concrete5\Api\Version\PackagistVersonCollection::create('concrete5/concrete5', $composer, $filesystem)
     // Only track 5.7.5.* and 8.*
-    ->addFromComposer('{5.7.5.*,8.*}')
+    ->addFromComposer(['/^5\.7\.5(?:\.\d+)*$/', '/^8(?:\.\d+)*$/'])
     // Add the development version too
     ->add('dev-develop', '8.x-dev')
 ;

--- a/src/Version/PackagistVersonCollection.php
+++ b/src/Version/PackagistVersonCollection.php
@@ -6,7 +6,6 @@ use Concrete5\Api\Composer\Composer;
 use Illuminate\Filesystem\Filesystem;
 use Sami\Version\Version;
 use Sami\Version\VersionCollection;
-use Symfony\Component\Finder\Glob;
 use Symfony\Component\Process\Process;
 
 class PackagistVersonCollection extends VersionCollection
@@ -39,14 +38,14 @@ class PackagistVersonCollection extends VersionCollection
         });
     }
 
-    public function addFromComposer($grep = '')
+    public function addFromComposer(array $versionFilterRegularExpressions = [])
     {
-        $this->composer->do(function (Process $process, $composer) use ($grep) {
+        $this->composer->do(function (Process $process, $composer) use ($versionFilterRegularExpressions) {
             $process->setCommandLine("{$composer} show {$this->package} --no-ansi --available --no-interaction")
-                ->run(function ($stream, $result) use ($grep) {
+                ->run(function ($stream, $result) use ($versionFilterRegularExpressions) {
                     if ($stream === 'out') {
                         if (preg_match('/^versions\s:\s(.+?)$/m', $result, $matches)) {
-                            $this->handleComposerVersions($matches[1], $grep);
+                            $this->handleComposerVersions($matches[1], $versionFilterRegularExpressions);
                         }
                     }
                 });
@@ -55,10 +54,10 @@ class PackagistVersonCollection extends VersionCollection
         return $this;
     }
 
-    protected function handleComposerVersions(string $composerVersions, $grep)
+    protected function handleComposerVersions(string $composerVersions, $versionFilterRegularExpressions)
     {
         $versions = array_reverse(explode(', ', $composerVersions));
-        foreach ($this->filteredVersions($versions, $grep) as $version) {
+        foreach ($this->filteredVersions($versions, $versionFilterRegularExpressions) as $version) {
             $this->add($version);
         }
     }
@@ -66,13 +65,8 @@ class PackagistVersonCollection extends VersionCollection
     protected function filteredVersions(array $versions, $filter)
     {
         if (!$filter instanceof \Closure && $filter) {
-            $regexes = array();
-            foreach ((array)$filter as $f) {
-                $regexes[] = Glob::toRegex($f);
-            }
-
-            $filter = function ($version) use ($regexes) {
-                foreach ($regexes as $regex) {
+            $filter = function ($version) use ($filter) {
+                foreach ((array) $filter as $regex) {
                     if (preg_match($regex, $version)) {
                         return true;
                     }


### PR DESCRIPTION
Do we really want to document RC versions (like for instance [8.2.0RC2](http://documentation.concrete5.org/api/8.2.0RC2/index.html))?
If not, what about documenting only numeric versions?