### PR TITLE
Add CLI command to check if there's some version to be built

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
             "name": "Michael Krasnow",
             "email": "mnkras@gmail.com"
         }
-    ]
+    ],
+    "scripts": {
+        "new-versions-available": [
+            "Concrete5\\Api\\Composer\\Script\\NewVersionsAvailable::run"
+        ]
+    }
 }

--- a/src/Composer/Script/NewVersionsAvailable.php
+++ b/src/Composer/Script/NewVersionsAvailable.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Concrete5\Api\Composer\Script;
+
+use Composer\Script\Event;
+use RuntimeException;
+
+class NewVersionsAvailable
+{
+    /**
+     * @param Event $event
+     *
+     * @throws RuntimeException
+     *
+     * @return int
+     */
+    public static function run(Event $event): int
+    {
+        $missingVersions = static::getMissingVersions();
+        if (count($missingVersions) === 0) {
+            throw new RuntimeException('No version need to be built.');
+        }
+        $event->getIO()->write('# Missing versions');
+        foreach ($missingVersions as $missingVersion) {
+            $event->getIO()->write($missingVersion);
+        }
+        return 0;
+    }
+
+    /**
+     * @return string[]
+     */
+    protected static function getMissingVersions(): array
+    {
+        $result = [];
+        $config = require dirname(__DIR__, 3) . '/sami_config.php';
+        $buildDir = $config['build_dir'];
+        $project = $config['project'];
+        foreach ($project->getVersions() as $version) {
+            if (!is_dir(str_replace('%version%', $version->getName(), $buildDir))) {
+                $result[] = $version->getName();
+            }
+        }
+        return $result;
+    }
+}


### PR DESCRIPTION
What about adding a way to automatically build new concrete5 versions?

With this pull request, we can schedule a cron job like this:

```
composer run-script new-versions-available && \
    php ./vendor/bin/sami.php parse sami_config.php && \
    php ./vendor/bin/sami.php render sami_config.php
```