### PR TITLE
Skip doc generation for 8.2.1 through 8.3.2

### DIFF
--- a/sami_config.php
+++ b/sami_config.php
@@ -18,7 +18,7 @@ $composer = (new \Concrete5\Api\Composer\Composer($filesystem, $inputDir))
 // Set up a new version collection that gets versions from packagist
 $versions = \Concrete5\Api\Version\PackagistVersonCollection::create('concrete5/concrete5', $composer, $filesystem)
     // Only track 5.7.5.* and 8.*
-    ->addFromComposer(['/^5\.7\.5(?:\.\d+)*$/', '/^8(?:\.\d+)*$/'])
+    ->addFromComposer(['/^5\.7\.5(?:\.\d+)*$/', '/^8(?:\.[014]\.\d+)*$/', '/^8(?:\.2\.[^1])*$/', '/^8(?:\.3\.[^012])*$/'])
     // Add the development version too
     ->add('dev-develop', '8.x-dev')
 ;


### PR DESCRIPTION
Ignore generating docs for 8.2.1 through 8.3.2. Something in `Concrete\Core\Express\Search\ColumnSet\Available` was introduced in 8.2.1 and removed in 8.4.0 which cased the renderer to fail on that part. I'm not sure what, however.

Ideally this should be investigated and this change reverted when the cause is found and fixed.


```
Version 8.2.1
  Parsing ################################ 65%                   13 errors
          Concrete\Core\Express\Search\ColumnSet\Available

Version 8.3.0
  Parsing ################################ 65%                   72 errors
          Concrete\Core\Express\Search\ColumnSet\Available

Version 8.3.1
  Parsing ################################ 65%                   76 errors
          Concrete\Core\Express\Search\ColumnSet\Available

Version 8.3.2
  Parsing ################################ 65%                   77 errors
          Concrete\Core\Express\Search\ColumnSet\Available

```